### PR TITLE
Update Johnny-Five to 0.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/norfolkjs/motorized-sumobot.git"
   },
   "dependencies": {
-    "johnny-five": "^0.9.58",
+    "johnny-five": "^0.15.0",
     "keypress": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The module serialport v3.1.2 used in johnny-five v0.9.58 isn't supported past node v5.x and fails to install.
Updating johnny-five to v0.15.0 (latest) fixes the issue. 
<br>
Tested on: 
- macOS High Sierra (`node v10.7.0` , `npm v6.1.0`)
- Windows 10 (`node v10.3.0` , `npm v6.1.0`)